### PR TITLE
Add support for more subscription types

### DIFF
--- a/Twocket.ts
+++ b/Twocket.ts
@@ -139,9 +139,17 @@ class Twocket {
 
         let body = `{"type":"${subscriptionType}","version":"1","condition":{"broadcaster_user_id":"${this.TWITCH_USER_ID}"},"transport":{"method":"websocket","session_id":"${this.TWITCH_SOCKET_ID}"}}`;
 
-        if (subscriptionType == "channel.raid") {
-            //NOTE This is hardcoded to only create subscriptions for raids coming to the channel
-            body = `{"type":"${subscriptionType}","version":"1","condition":{"to_broadcaster_user_id":"${this.TWITCH_USER_ID}"},"transport":{"method":"websocket","session_id":"${this.TWITCH_SOCKET_ID}"}}`;
+        const specificBody = {
+            ["channel.raid"]: `{"type":"${subscriptionType}","version":"1","condition":{"to_broadcaster_user_id":"${this.TWITCH_USER_ID}"},"transport":{"method":"websocket","session_id":"${this.TWITCH_SOCKET_ID}"}}`,
+            ["channel.follow"]: `{"type":"${subscriptionType}","version":"2","condition":{"broadcaster_user_id":"${this.TWITCH_USER_ID}","moderator_user_id":"${this.TWITCH_USER_ID}"},"transport":{"method":"websocket","session_id":"${this.TWITCH_SOCKET_ID}"}}`,
+            ["channel.chat.message"]: `{"type":"${subscriptionType}","version":"1","condition":{"broadcaster_user_id":"${this.TWITCH_USER_ID}","user_id":"${this.TWITCH_USER_ID}"},"transport":{"method":"websocket","session_id":"${this.TWITCH_SOCKET_ID}"}}`,
+            ["channel.shoutout.create"]: `{"type":"${subscriptionType}","version":"1","condition":{"broadcaster_user_id":"${this.TWITCH_USER_ID}","moderator_user_id":"${this.TWITCH_USER_ID}"},"transport":{"method":"websocket","session_id":"${this.TWITCH_SOCKET_ID}"}}`,
+            ["channel.shoutout.receive"]: `{"type":"${subscriptionType}","version":"1","condition":{"broadcaster_user_id":"${this.TWITCH_USER_ID}","moderator_user_id":"${this.TWITCH_USER_ID}"},"transport":{"method":"websocket","session_id":"${this.TWITCH_SOCKET_ID}"}}`,
+            ["stream.offline"]: `{"type":"${subscriptionType}","version":"1","condition":{"broadcaster_user_id":"${this.TWITCH_USER_ID}"},"transport":{"method":"websocket","session_id":"${this.TWITCH_SOCKET_ID}"}}`
+        }
+
+        if (subscriptionType in specificBody) {
+            body = specificBody[subscriptionType];
         }
 
         const options = {

--- a/lib/Twocket.js
+++ b/lib/Twocket.js
@@ -118,10 +118,16 @@ var Twocket = /** @class */ (function () {
     Twocket.prototype.sendSubscriptionRequestToTwitch = function (subscriptionType) {
         //TODO Potential validation on the subscrtiptionType to ensure the user is requesting a 
         //valid (or already requested sub type).
-        var body = "{\"type\":\"".concat(subscriptionType, "\",\"version\":\"1\",\"condition\":{\"broadcaster_user_id\":\"").concat(this.TWITCH_USER_ID, "\"},\"transport\":{\"method\":\"websocket\",\"session_id\":\"").concat(this.TWITCH_SOCKET_ID, "\"}}");
-        if (subscriptionType == "channel.raid") {
-            //NOTE This is hardcoded to only create subscriptions for raids coming to the channel
-            body = "{\"type\":\"".concat(subscriptionType, "\",\"version\":\"1\",\"condition\":{\"to_broadcaster_user_id\":\"").concat(this.TWITCH_USER_ID, "\"},\"transport\":{\"method\":\"websocket\",\"session_id\":\"").concat(this.TWITCH_SOCKET_ID, "\"}}");
+        const specificBody = {
+            ["channel.raid"]: `{"type":"${subscriptionType}","version":"1","condition":{"to_broadcaster_user_id":"${this.TWITCH_USER_ID}"},"transport":{"method":"websocket","session_id":"${this.TWITCH_SOCKET_ID}"}}`,
+            ["channel.follow"]: `{"type":"${subscriptionType}","version":"2","condition":{"broadcaster_user_id":"${this.TWITCH_USER_ID}","moderator_user_id":"${this.TWITCH_USER_ID}"},"transport":{"method":"websocket","session_id":"${this.TWITCH_SOCKET_ID}"}}`,
+            ["channel.chat.message"]: `{"type":"${subscriptionType}","version":"1","condition":{"broadcaster_user_id":"${this.TWITCH_USER_ID}","user_id":"${this.TWITCH_USER_ID}"},"transport":{"method":"websocket","session_id":"${this.TWITCH_SOCKET_ID}"}}`,
+            ["channel.shoutout.create"]: `{"type":"${subscriptionType}","version":"1","condition":{"broadcaster_user_id":"${this.TWITCH_USER_ID}","moderator_user_id":"${this.TWITCH_USER_ID}"},"transport":{"method":"websocket","session_id":"${this.TWITCH_SOCKET_ID}"}}`,
+            ["channel.shoutout.receive"]: `{"type":"${subscriptionType}","version":"1","condition":{"broadcaster_user_id":"${this.TWITCH_USER_ID}","moderator_user_id":"${this.TWITCH_USER_ID}"},"transport":{"method":"websocket","session_id":"${this.TWITCH_SOCKET_ID}"}}`,
+            ["stream.offline"]: `{"type":"${subscriptionType}","version":"1","condition":{"broadcaster_user_id":"${this.TWITCH_USER_ID}"},"transport":{"method":"websocket","session_id":"${this.TWITCH_SOCKET_ID}"}}`
+        }
+        if (subscriptionType in specificBody) {
+            body = specificBody[subscriptionType];
         }
         var options = {
             method: 'POST',


### PR DESCRIPTION
While any subscription type can be assigned in Twocket, the required parameters within the request body change for various reasons (updated version types, extra data needed, etc).

This PR aims to add some further support for a vast majority of supported types.